### PR TITLE
fix: make AbstractILIASDatabaseDetector compatible with ILIAS 7.25.

### DIFF
--- a/vendor/srag/dic/src/Database/AbstractILIASDatabaseDetector.php
+++ b/vendor/srag/dic/src/Database/AbstractILIASDatabaseDetector.php
@@ -995,4 +995,12 @@ abstract class AbstractILIASDatabaseDetector implements DatabaseInterface
     {
         return $this->db->useSlave($bool);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function primaryExistsByFields(string $table_name, array $field_names): bool
+    {
+        return $this->db->primaryExistsByFields($table_name, $field_names);
+    }
 }


### PR DESCRIPTION
This should restore compatibility with ILIAS 7.25.
Without the change, an error is generated for certain actions such as trying to save an attendance list.